### PR TITLE
Fixing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ See the included Fritzing diagram (.fzz file) for details.
 
 ### License
 
-<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Sleep Sensei</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="www.JeremyAdamWilson.com">Jeremy Wilson</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Sleep Sensei</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://www.JeremyAdamWilson.com">Jeremy Wilson</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
 
 


### PR DESCRIPTION
I've added `http://` to `href="http://www.JeremyAdamWilson.com"`

Without http the link moves the user to the 404 error page https://github.com/jerwil/SleepSensei/blob/master/www.JeremyAdamWilson.com
